### PR TITLE
esp32_devkit_v1_tx: change filenames case for building on linux

### DIFF
--- a/examples/esp32_devkit_v1_tx/src/modeXiroMini.cpp
+++ b/examples/esp32_devkit_v1_tx/src/modeXiroMini.cpp
@@ -3,7 +3,7 @@
 #include <esp_task_wdt.h>
 
 //include for HXRCLOG usage
-#include "HX_ESPNOW_RC_COMMON.h"
+#include "HX_ESPNOW_RC_Common.h"
 
 #include "modeXiroMini.h"
 #include "tx_config.h"

--- a/examples/esp32_devkit_v1_tx/src/smartport.cpp
+++ b/examples/esp32_devkit_v1_tx/src/smartport.cpp
@@ -1,10 +1,10 @@
-#include "Smartport.h"
+#include "smartport.h"
 #include "tx_config.h"
 
 //https://github.com/yaapu/FrskyTelemetryScript/wiki/FrSky-SPort-protocol-specs
 
 //include for HXRCLOG usage
-#include "HX_ESPNOW_RC_COMMON.h"
+#include "HX_ESPNOW_RC_Common.h"
 
 #define FRSKY_START_STOP  0x7e
 #define FRSKY_BYTESTUFF   0x7d

--- a/examples/esp32_devkit_v1_tx/src/tx_config.cpp
+++ b/examples/esp32_devkit_v1_tx/src/tx_config.cpp
@@ -1,4 +1,4 @@
-#include "Smartport.h"
+#include "smartport.h"
 #include "tx_config.h"
 
 TXConfigProfile TXConfigProfile::profiles[PROFILES_COUNT];


### PR DESCRIPTION
more filename case changes to allow building on linux